### PR TITLE
Use base64 encoding to obfuscate the original code statements

### DIFF
--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -10,6 +10,7 @@ def create_app(test_config=None):
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__)
     app.config.from_object('config.Config')
+    app.jinja_options['extensions'].append('jinja2_base64_filters.Base64Filters')
 
     if test_config is None:
         # load the instance config, if it exists, when not testing

--- a/parsons/templates/puzzle.html
+++ b/parsons/templates/puzzle.html
@@ -37,7 +37,7 @@
         <script src="{{ url_for('static', filename='parsons.js') }}"></script>
         <script src="{{ url_for('static', filename='lis.js') }}"></script>
         <script>
-        var initial = {{ program['code']|tojson }}
+        var initial = atob("{{ program['code']|b64encode }}");
 
         function displayErrors(fb) {
             if(fb.errors.length > 0) {

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'flask_sqlalchemy',
         'python-dotenv',
         'psycopg2',
+        'jinja2-base64-filters',
     ],
     #    extras_require={
     #        'test': [


### PR DESCRIPTION
Am wanting to use this to create challenges for my (sixth form) students - but when I looked at the generated puzzles and saw the code statements in the script, I wondered if there was a simple way to make it harder for enterprising students to not be able to see the original statements in order.
Found a useful jinja extension that can convert text to base64, which the javascript can then convert back, but of course in the script on the page it looks illegible to the casual observer.